### PR TITLE
Add rate options, furlough periods and caching

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,8 +12,16 @@
         <p class="disclaimer">This tool provides an approximate estimation only and is not financial advice. Consult a professional for advice specific to your situation.</p>
 
         <div class="form-group">
-            <label for="dailyRate">Daily Rate (ex GST)</label>
-            <input type="number" id="dailyRate" value="800">
+            <label for="rate">Rate (ex GST)</label>
+            <input type="number" id="rate" value="800">
+        </div>
+        <div class="form-group">
+            <label for="rateType">Rate Type</label>
+            <select id="rateType">
+                <option value="hourly">Hourly</option>
+                <option value="daily" selected>Daily</option>
+                <option value="weekly">Weekly</option>
+            </select>
         </div>
 
         <div class="form-group">
@@ -41,6 +49,19 @@
             <label for="workingDays">Working Days in Period</label>
             <input type="number" id="workingDays" value="0" readonly>
         </div>
+        <div class="form-group">
+            <label for="holidayDays">Holiday Days Taken</label>
+            <input type="number" id="holidayDays" value="0">
+        </div>
+        <div class="form-group" id="furloughContainer">
+            <label>Furlough Periods</label>
+            <div class="furlough-period">
+                <input type="date" class="furlough-start">
+                <input type="date" class="furlough-end">
+                <button type="button" class="remove-furlough">Remove</button>
+            </div>
+            <button type="button" id="addFurlough">Add Furlough Period</button>
+        </div>
 
         <div class="form-group">
             <label for="gstRate">GST Rate (%)</label>
@@ -55,7 +76,7 @@
 
         <div class="form-group">
             <label for="hoursPerDay">Working Hours Per Day</label>
-            <input type="number" id="hoursPerDay" value="8">
+            <input type="number" id="hoursPerDay" value="7.2">
         </div>
 
         <button id="calculate">Calculate</button>

--- a/docs/style.css
+++ b/docs/style.css
@@ -23,6 +23,24 @@ h1 {
     margin-bottom: 15px;
 }
 
+.furlough-period {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 5px;
+}
+
+.furlough-period input[type="date"] {
+    flex: 1;
+}
+
+.remove-furlough {
+    background: #dc3545;
+}
+
+.remove-furlough:hover {
+    background: #c82333;
+}
+
 label {
     display: block;
     margin-bottom: 5px;


### PR DESCRIPTION
## Summary
- add rate type selector and conversion logic
- allow entering holiday days and multiple furlough periods
- auto-calculate when any field changes
- cache holiday API calls and working-day calculations
- style furlough section

## Testing
- `node -c docs/script.js`