### PR TITLE
Add workflow for GitHub Pages previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,30 @@
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./docs/
+          preview-branch: main
+          umbrella-dir: docs/pr-preview
+          pages-base-path: docs


### PR DESCRIPTION
## Summary
- enable PR preview deploys via rossjrw/pr-preview-action
- grant write permissions so GITHUB_TOKEN can push preview updates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `git status --short`