### PR TITLE
Improve salary package accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The calculator can generate a share link with your inputs. Click **Copy Share Li
 
 The code now includes a basic public holiday service. It attempts to retrieve holiday data from the public API at [Nager.Date](https://date.nager.at) and falls back to an internal list if the request fails.
 
-The results page also explains the equivalent full time salary for your entered rate and estimates your total salary package including superannuation. Current Australian tax brackets are fetched from an API when possible (with a local fallback) to estimate annual tax and typical take‑home pay. Your estimated net income is shown per your selected invoice frequency (weekly, fortnightly, monthly or quarterly).
+The results page also explains the equivalent full‑time salary for your entered rate. Hourly, daily and weekly rates are converted to an annual figure using a 7.2 hour day and 260 working days per year. Tax calculations rely on the official ATO tables provided in [`aus_tax_brackets.js`](docs/aus_tax_brackets.js). From this the tool derives an indicative total salary package including superannuation and any HECS repayments and shows your approximate take‑home pay for each invoice cycle (weekly, fortnightly, monthly or quarterly).
 
 ## Design system
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -462,6 +462,6 @@
       >
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
   </body>
 </html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,3 +1,5 @@
+import { AusTaxBrackets } from "./aus_tax_brackets.js";
+
 class HolidayService {
   static FALLBACK_HOLIDAYS = {
     2024: {
@@ -549,11 +551,13 @@ class PayCalculator {
     otherRates = { collectGst: gstRate > 0, taxRate, superRate, hecsRate };
     const annualDays = 260;
     const fteSalary = dailyRate * annualDays;
-    const year = startDateVal
-      ? new Date(startDateVal).getFullYear()
-      : new Date().getFullYear();
-    const brackets = await TaxService.getBrackets(year);
-    const fteTax = TaxService.calcTax(fteSalary, brackets);
+    const dateForFy = startDateVal ? new Date(startDateVal) : new Date();
+    const fyStart =
+      dateForFy.getMonth() >= 6
+        ? dateForFy.getFullYear()
+        : dateForFy.getFullYear() - 1;
+    const fy = `${fyStart}-${String((fyStart + 1) % 100).padStart(2, "0")}`;
+    const fteTax = AusTaxBrackets.calculateTax(fteSalary, fy);
     const fteSuper = fteSalary * superRate;
     const fteHecs = fteSalary * hecsRate;
     const ftePackage = fteSalary + fteSuper;


### PR DESCRIPTION
## Summary
- use ATO tax brackets script in the salary calculations
- load the main script as a module
- document accurate salary package and take-home pay calculation

Prettier was run on `docs/index.html` and `docs/script.js` and passed.