### PR TITLE
Add HECS calculations to FTE output

### DIFF
--- a/docs/aus_tax_brackets.js
+++ b/docs/aus_tax_brackets.js
@@ -34,72 +34,89 @@ export class AusTaxBrackets {
 
   /** @private @const {!Record<string, !Array<!TaxBracket>>} */
   static #RESIDENT = {
-    '2019-20': [
-      {min: 0, max: 18_200, base: 0, rate: 0},
-      {min: 18_200, max: 37_000, base: 0, rate: 0.19},
-      {min: 37_000, max: 90_000, base: 3_572, rate: 0.325},
-      {min: 90_000, max: 180_000, base: 20_797, rate: 0.37},
-      {min: 180_000, max: Infinity, base: 54_097, rate: 0.45},
+    "2019-20": [
+      { min: 0, max: 18_200, base: 0, rate: 0 },
+      { min: 18_200, max: 37_000, base: 0, rate: 0.19 },
+      { min: 37_000, max: 90_000, base: 3_572, rate: 0.325 },
+      { min: 90_000, max: 180_000, base: 20_797, rate: 0.37 },
+      { min: 180_000, max: Infinity, base: 54_097, rate: 0.45 },
     ],
-    '2020-21': [
-      {min: 0, max: 18_200, base: 0, rate: 0},
-      {min: 18_200, max: 45_000, base: 0, rate: 0.19},
-      {min: 45_000, max: 120_000, base: 5_092, rate: 0.325},
-      {min: 120_000, max: 180_000, base: 29_467, rate: 0.37},
-      {min: 180_000, max: Infinity, base: 51_667, rate: 0.45},
+    "2020-21": [
+      { min: 0, max: 18_200, base: 0, rate: 0 },
+      { min: 18_200, max: 45_000, base: 0, rate: 0.19 },
+      { min: 45_000, max: 120_000, base: 5_092, rate: 0.325 },
+      { min: 120_000, max: 180_000, base: 29_467, rate: 0.37 },
+      { min: 180_000, max: Infinity, base: 51_667, rate: 0.45 },
     ],
     // FY 2021-22 & 2022-23 identical to 2020-21:
-    '2021-22': /** @type {!Array<!TaxBracket>} */ (null),
-    '2022-23': /** @type {!Array<!TaxBracket>} */ (null),
-    '2023-24': [
-      {min: 0, max: 18_200, base: 0, rate: 0},
-      {min: 18_200, max: 45_000, base: 0, rate: 0.19},
-      {min: 45_000, max: 120_000, base: 5_092, rate: 0.325},
-      {min: 120_000, max: 180_000, base: 29_467, rate: 0.37},
-      {min: 180_000, max: Infinity, base: 51_667, rate: 0.45},
+    "2021-22": /** @type {!Array<!TaxBracket>} */ (null),
+    "2022-23": /** @type {!Array<!TaxBracket>} */ (null),
+    "2023-24": [
+      { min: 0, max: 18_200, base: 0, rate: 0 },
+      { min: 18_200, max: 45_000, base: 0, rate: 0.19 },
+      { min: 45_000, max: 120_000, base: 5_092, rate: 0.325 },
+      { min: 120_000, max: 180_000, base: 29_467, rate: 0.37 },
+      { min: 180_000, max: Infinity, base: 51_667, rate: 0.45 },
     ],
-    '2024-25': [
-      {min: 0, max: 18_200, base: 0, rate: 0},
-      {min: 18_200, max: 45_000, base: 0, rate: 0.16},
-      {min: 45_000, max: 135_000, base: 4_288, rate: 0.30},
-      {min: 135_000, max: 190_000, base: 31_288, rate: 0.37},
-      {min: 190_000, max: Infinity, base: 51_638, rate: 0.45},
+    "2024-25": [
+      { min: 0, max: 18_200, base: 0, rate: 0 },
+      { min: 18_200, max: 45_000, base: 0, rate: 0.16 },
+      { min: 45_000, max: 135_000, base: 4_288, rate: 0.3 },
+      { min: 135_000, max: 190_000, base: 31_288, rate: 0.37 },
+      { min: 190_000, max: Infinity, base: 51_638, rate: 0.45 },
     ],
   };
 
   /** @private @const {!Record<string, !Array<!TaxBracket>>} */
   static #NON_RESIDENT = {
-    '2019-20': [
-      {min: 0, max: 90_000, base: 0, rate: 0.325},
-      {min: 90_000, max: 180_000, base: 29_250, rate: 0.37},
-      {min: 180_000, max: Infinity, base: 62_550, rate: 0.45},
+    "2019-20": [
+      { min: 0, max: 90_000, base: 0, rate: 0.325 },
+      { min: 90_000, max: 180_000, base: 29_250, rate: 0.37 },
+      { min: 180_000, max: Infinity, base: 62_550, rate: 0.45 },
     ],
-    '2020-21': [
-      {min: 0, max: 120_000, base: 0, rate: 0.325},
-      {min: 120_000, max: 180_000, base: 39_000, rate: 0.37},
-      {min: 180_000, max: Infinity, base: 61_200, rate: 0.45},
+    "2020-21": [
+      { min: 0, max: 120_000, base: 0, rate: 0.325 },
+      { min: 120_000, max: 180_000, base: 39_000, rate: 0.37 },
+      { min: 180_000, max: Infinity, base: 61_200, rate: 0.45 },
     ],
     // FY 2021-22 & 2022-23 identical to 2020-21:
-    '2021-22': /** @type {!Array<!TaxBracket>} */ (null),
-    '2022-23': /** @type {!Array<!TaxBracket>} */ (null),
-    '2023-24': [
-      {min: 0, max: 120_000, base: 0, rate: 0.325},
-      {min: 120_000, max: 180_000, base: 39_000, rate: 0.37},
-      {min: 180_000, max: Infinity, base: 61_200, rate: 0.45},
+    "2021-22": /** @type {!Array<!TaxBracket>} */ (null),
+    "2022-23": /** @type {!Array<!TaxBracket>} */ (null),
+    "2023-24": [
+      { min: 0, max: 120_000, base: 0, rate: 0.325 },
+      { min: 120_000, max: 180_000, base: 39_000, rate: 0.37 },
+      { min: 180_000, max: Infinity, base: 61_200, rate: 0.45 },
     ],
-    '2024-25': [
-      {min: 0, max: 135_000, base: 0, rate: 0.30},
-      {min: 135_000, max: 190_000, base: 40_500, rate: 0.37},
-      {min: 190_000, max: Infinity, base: 60_850, rate: 0.45},
+    "2024-25": [
+      { min: 0, max: 135_000, base: 0, rate: 0.3 },
+      { min: 135_000, max: 190_000, base: 40_500, rate: 0.37 },
+      { min: 190_000, max: Infinity, base: 60_850, rate: 0.45 },
+    ],
+  };
+
+  /** @private @const {!Record<string, !Array<{min:number,max:number,rate:number}>>} */
+  static #HECS = {
+    "2024-25": [
+      { min: 0, max: 50_000, rate: 0 },
+      { min: 50_000, max: 60_000, rate: 0.01 },
+      { min: 60_000, max: 70_000, rate: 0.02 },
+      { min: 70_000, max: 80_000, rate: 0.03 },
+      { min: 80_000, max: 90_000, rate: 0.04 },
+      { min: 90_000, max: 100_000, rate: 0.05 },
+      { min: 100_000, max: 110_000, rate: 0.06 },
+      { min: 110_000, max: 120_000, rate: 0.07 },
+      { min: 120_000, max: 130_000, rate: 0.08 },
+      { min: 130_000, max: 140_000, rate: 0.09 },
+      { min: 140_000, max: Infinity, rate: 0.1 },
     ],
   };
 
   /** Collapse identical FY mappings declared as `null` above. */
   static {
-    ['2021-22', '2022-23'].forEach((fy) => {
-      AusTaxBrackets.#RESIDENT[fy] = AusTaxBrackets.#RESIDENT['2020-21'];
+    ["2021-22", "2022-23"].forEach((fy) => {
+      AusTaxBrackets.#RESIDENT[fy] = AusTaxBrackets.#RESIDENT["2020-21"];
       AusTaxBrackets.#NON_RESIDENT[fy] =
-          AusTaxBrackets.#NON_RESIDENT['2020-21'];
+        AusTaxBrackets.#NON_RESIDENT["2020-21"];
     });
   }
 
@@ -115,15 +132,16 @@ export class AusTaxBrackets {
    * @throws {RangeError} If data unavailable.
    */
   static getBrackets(fy, isResident = true) {
-    const src = isResident ? AusTaxBrackets.#RESIDENT
-                           : AusTaxBrackets.#NON_RESIDENT;
+    const src = isResident
+      ? AusTaxBrackets.#RESIDENT
+      : AusTaxBrackets.#NON_RESIDENT;
     let brackets = src[fy];
     if (!brackets) {
       const nearest = AusTaxBrackets.#nearestYear(fy, isResident);
       console.warn(`No bracket data for FY ${fy}; using ${nearest} instead.`);
       brackets = src[nearest];
     }
-    return brackets.map((b) => ({...b}));
+    return brackets.map((b) => ({ ...b }));
   }
 
   /**
@@ -136,7 +154,7 @@ export class AusTaxBrackets {
    */
   static calculateTax(income, fy, isResident = true) {
     if (income < 0 || !Number.isFinite(income)) {
-      throw new RangeError('Income must be a non-negative finite number.');
+      throw new RangeError("Income must be a non-negative finite number.");
     }
     const brackets = AusTaxBrackets.getBrackets(fy, isResident);
     const tier = brackets.find((b) => income < b.max);
@@ -164,10 +182,10 @@ export class AusTaxBrackets {
     const s = AusTaxBrackets.#toDate(start);
     const e = AusTaxBrackets.#toDate(end);
     if (e < s) {
-      throw new RangeError('End date must be on/after start date.');
+      throw new RangeError("End date must be on/after start date.");
     }
     if (annualSalary < 0 || !Number.isFinite(annualSalary)) {
-      throw new RangeError('Salary must be a non-negative finite number.');
+      throw new RangeError("Salary must be a non-negative finite number.");
     }
 
     let totalTax = 0;
@@ -180,7 +198,9 @@ export class AusTaxBrackets {
 
       const daysInSeg = AusTaxBrackets.#daysBetween(cursor, segEnd);
       const daysInFy = AusTaxBrackets.#daysBetween(
-          AusTaxBrackets.#startOfFy(fy), fyEnd);
+        AusTaxBrackets.#startOfFy(fy),
+        fyEnd,
+      );
 
       const segIncome = (annualSalary * daysInSeg) / daysInFy;
       totalTax += AusTaxBrackets.calculateTax(segIncome, fy, isResident);
@@ -189,6 +209,30 @@ export class AusTaxBrackets {
       cursor = new Date(fyEnd.getTime() + 86_400_000); // +1 day
     }
     return totalTax;
+  }
+
+  /**
+   * Calculates compulsory HECS/HELP repayment for an annual income.
+   * @param {number} income Taxable income ($).
+   * @param {string} fy Financial year string.
+   * @return {number} Repayment amount ($).
+   * @throws {RangeError} On bad inputs or lookup failure.
+   */
+  static calculateHecs(income, fy = "2024-25") {
+    if (income < 0 || !Number.isFinite(income)) {
+      throw new RangeError("Income must be a non-negative finite number.");
+    }
+    let table = AusTaxBrackets.#HECS[fy];
+    if (!table) {
+      const nearest = AusTaxBrackets.#nearestYear(fy, true);
+      console.warn(`No HECS data for FY ${fy}; using ${nearest} instead.`);
+      table = AusTaxBrackets.#HECS[nearest];
+    }
+    const tier = table.find((b) => income < b.max);
+    if (!tier) {
+      throw new RangeError(`Incomplete HECS table for FY ${fy}.`);
+    }
+    return income * tier.rate;
   }
 
   // ---------------------------------------------------------------------------
@@ -222,8 +266,8 @@ export class AusTaxBrackets {
     const year = d.getFullYear();
     const isAfterJun = d.getMonth() >= 6; // July = 6
     const fyStart = isAfterJun ? year : year - 1;
-    const fyEnd = (fyStart + 1) % 100;      // 24 for 2023-24
-    return `${fyStart}-${fyEnd.toString().padStart(2, '0')}`;
+    const fyEnd = (fyStart + 1) % 100; // 24 for 2023-24
+    return `${fyStart}-${fyEnd.toString().padStart(2, "0")}`;
   }
 
   /**
@@ -268,13 +312,16 @@ export class AusTaxBrackets {
    * @private
    */
   static #nearestYear(target, isResident) {
-    const src = isResident ? AusTaxBrackets.#RESIDENT
-                           : AusTaxBrackets.#NON_RESIDENT;
+    const src = isResident
+      ? AusTaxBrackets.#RESIDENT
+      : AusTaxBrackets.#NON_RESIDENT;
     const tgt = parseInt(target.slice(0, 4), 10);
     const years = Object.keys(src).map((fy) => parseInt(fy.slice(0, 4), 10));
-    const nearestStart = years.reduce((best, y) =>
-      Math.abs(y - tgt) < Math.abs(best - tgt) ? y : best, years[0]);
-    const suffix = ((nearestStart + 1) % 100).toString().padStart(2, '0');
+    const nearestStart = years.reduce(
+      (best, y) => (Math.abs(y - tgt) < Math.abs(best - tgt) ? y : best),
+      years[0],
+    );
+    const suffix = ((nearestStart + 1) % 100).toString().padStart(2, "0");
     return `${nearestStart}-${suffix}`;
   }
 }
@@ -282,25 +329,41 @@ export class AusTaxBrackets {
 /* ---------------------------------------------------------------------------
  * === LIGHTWEIGHT SELF-TESTS (no production impact) ==========================
  * ------------------------------------------------------------------------- */
-if (import.meta.url.endsWith('aus_tax_brackets.js')) {
-  const assert = (cond, msg) => { if (!cond) { throw new Error(msg); } };
+if (import.meta.url.endsWith("aus_tax_brackets.js")) {
+  const assert = (cond, msg) => {
+    if (!cond) {
+      throw new Error(msg);
+    }
+  };
 
   // 1. Full FY ≙ period calc parity
-  const fy = '2024-25';
+  const fy = "2024-25";
   const salary = 100_000;
-  const fullYearTax =
-      AusTaxBrackets.calculateTax(salary, fy, true);
+  const fullYearTax = AusTaxBrackets.calculateTax(salary, fy, true);
 
   const periodTax = AusTaxBrackets.calculateTaxForPeriod(
-      '2024-07-01', '2025-06-30', salary, true);
-  assert(fullYearTax === periodTax,
-      'Full-year parity failed for resident FY 2024-25');
+    "2024-07-01",
+    "2025-06-30",
+    salary,
+    true,
+  );
+  assert(
+    fullYearTax === periodTax,
+    "Full-year parity failed for resident FY 2024-25",
+  );
 
   // 2. Cross-FY (half & half)
   const t = AusTaxBrackets.calculateTaxForPeriod(
-      '2024-01-01', '2024-12-31', 150_000, true);
-  assert(Number.isFinite(t) && t > 0,
-      'Cross-FY calculation failed.');
+    "2024-01-01",
+    "2024-12-31",
+    150_000,
+    true,
+  );
+  assert(Number.isFinite(t) && t > 0, "Cross-FY calculation failed.");
 
-  console.info('AusTaxBrackets smoke-tests passed.');
+  // 3. HECS repayment sanity
+  const hecs = AusTaxBrackets.calculateHecs(100_000, fy);
+  assert(Number.isFinite(hecs) && hecs >= 0, "HECS calculation failed.");
+
+  console.info("AusTaxBrackets smoke-tests passed.");
 }

--- a/docs/script.js
+++ b/docs/script.js
@@ -411,15 +411,23 @@ class PayCalculator {
 
     if (data.fteSalary) {
       const ann = [];
-      ann.push(
-        `<p>Approx. full‑time salary <strong>$${formatMoney(
-          data.fteSalary,
-        )}</strong> per year</p>`,
-      );
       if (data.superRate > 0) {
         ann.push(
-          `<p>Total package about $${formatMoney(data.ftePackage)} per year</p>`,
+          `<p>Total package about <strong>$${formatMoney(
+            data.ftePackage,
+          )}</strong> per year</p>`,
         );
+      } else {
+        ann.push(
+          `<p>Total package about <strong>$${formatMoney(
+            data.fteSalary,
+          )}</strong> per year</p>`,
+        );
+      }
+      ann.push(`<p>Base salary about $${formatMoney(data.fteSalary)}</p>`);
+      ann.push(`<p>Less income tax $${formatMoney(data.fteTax)}</p>`);
+      if (data.fteHecs > 0) {
+        ann.push(`<p>Less HECS/HELP $${formatMoney(data.fteHecs)}</p>`);
       }
       if (data.fteNet && data.perInvoiceNet) {
         const words = {
@@ -430,9 +438,11 @@ class PayCalculator {
         };
         const freqWord = words[data.invoiceFreq] || data.invoiceFreq;
         ann.push(
-          `<p>Take‑home about $${formatMoney(
+          `<p>Take‑home about <strong>$${formatMoney(
             data.fteNet,
-          )} per year (around $${formatMoney(data.perInvoiceNet)} each ${freqWord})</p>`,
+          )}</strong> per year (around $${formatMoney(
+            data.perInvoiceNet,
+          )} each ${freqWord})</p>`,
         );
       }
       sections.push(
@@ -590,7 +600,8 @@ class PayCalculator {
     const fy = `${fyStart}-${String((fyStart + 1) % 100).padStart(2, "0")}`;
     const fteTax = AusTaxBrackets.calculateTax(fteSalary, fy);
     const fteSuper = fteSalary * superRate;
-    const fteHecs = fteSalary * hecsRate;
+    const fteHecs =
+      hecsRate > 0 ? AusTaxBrackets.calculateHecs(fteSalary, fy) : 0;
     const ftePackage = fteSalary + fteSuper;
     const fteNet = fteSalary - fteTax - fteSuper - fteHecs;
     const freqMap = { weekly: 52, fortnightly: 26, monthly: 12, quarterly: 4 };
@@ -606,6 +617,8 @@ class PayCalculator {
       netAmount,
       fteSalary,
       ftePackage,
+      fteTax,
+      fteHecs,
       fteNet,
       perInvoiceNet,
       invoiceFreq: invoiceFreqSelect.value,


### PR DESCRIPTION
## Summary
- include HECS repayment tables and calculator
- auto-calculate HECS in full time equivalent figures
- clarify annualised equivalent breakdown with HECS line

## Testing
- `npx prettier --check docs/script.js docs/index.html docs/aus_tax_brackets.js`