### PR TITLE
Add HECS/HELP repayment calculations

### DIFF
--- a/docs/aus_tax_brackets.js
+++ b/docs/aus_tax_brackets.js
@@ -34,72 +34,97 @@ export class AusTaxBrackets {
 
   /** @private @const {!Record<string, !Array<!TaxBracket>>} */
   static #RESIDENT = {
-    '2019-20': [
-      {min: 0, max: 18_200, base: 0, rate: 0},
-      {min: 18_200, max: 37_000, base: 0, rate: 0.19},
-      {min: 37_000, max: 90_000, base: 3_572, rate: 0.325},
-      {min: 90_000, max: 180_000, base: 20_797, rate: 0.37},
-      {min: 180_000, max: Infinity, base: 54_097, rate: 0.45},
+    "2019-20": [
+      { min: 0, max: 18_200, base: 0, rate: 0 },
+      { min: 18_200, max: 37_000, base: 0, rate: 0.19 },
+      { min: 37_000, max: 90_000, base: 3_572, rate: 0.325 },
+      { min: 90_000, max: 180_000, base: 20_797, rate: 0.37 },
+      { min: 180_000, max: Infinity, base: 54_097, rate: 0.45 },
     ],
-    '2020-21': [
-      {min: 0, max: 18_200, base: 0, rate: 0},
-      {min: 18_200, max: 45_000, base: 0, rate: 0.19},
-      {min: 45_000, max: 120_000, base: 5_092, rate: 0.325},
-      {min: 120_000, max: 180_000, base: 29_467, rate: 0.37},
-      {min: 180_000, max: Infinity, base: 51_667, rate: 0.45},
+    "2020-21": [
+      { min: 0, max: 18_200, base: 0, rate: 0 },
+      { min: 18_200, max: 45_000, base: 0, rate: 0.19 },
+      { min: 45_000, max: 120_000, base: 5_092, rate: 0.325 },
+      { min: 120_000, max: 180_000, base: 29_467, rate: 0.37 },
+      { min: 180_000, max: Infinity, base: 51_667, rate: 0.45 },
     ],
     // FY 2021-22 & 2022-23 identical to 2020-21:
-    '2021-22': /** @type {!Array<!TaxBracket>} */ (null),
-    '2022-23': /** @type {!Array<!TaxBracket>} */ (null),
-    '2023-24': [
-      {min: 0, max: 18_200, base: 0, rate: 0},
-      {min: 18_200, max: 45_000, base: 0, rate: 0.19},
-      {min: 45_000, max: 120_000, base: 5_092, rate: 0.325},
-      {min: 120_000, max: 180_000, base: 29_467, rate: 0.37},
-      {min: 180_000, max: Infinity, base: 51_667, rate: 0.45},
+    "2021-22": /** @type {!Array<!TaxBracket>} */ (null),
+    "2022-23": /** @type {!Array<!TaxBracket>} */ (null),
+    "2023-24": [
+      { min: 0, max: 18_200, base: 0, rate: 0 },
+      { min: 18_200, max: 45_000, base: 0, rate: 0.19 },
+      { min: 45_000, max: 120_000, base: 5_092, rate: 0.325 },
+      { min: 120_000, max: 180_000, base: 29_467, rate: 0.37 },
+      { min: 180_000, max: Infinity, base: 51_667, rate: 0.45 },
     ],
-    '2024-25': [
-      {min: 0, max: 18_200, base: 0, rate: 0},
-      {min: 18_200, max: 45_000, base: 0, rate: 0.16},
-      {min: 45_000, max: 135_000, base: 4_288, rate: 0.30},
-      {min: 135_000, max: 190_000, base: 31_288, rate: 0.37},
-      {min: 190_000, max: Infinity, base: 51_638, rate: 0.45},
+    "2024-25": [
+      { min: 0, max: 18_200, base: 0, rate: 0 },
+      { min: 18_200, max: 45_000, base: 0, rate: 0.16 },
+      { min: 45_000, max: 135_000, base: 4_288, rate: 0.3 },
+      { min: 135_000, max: 190_000, base: 31_288, rate: 0.37 },
+      { min: 190_000, max: Infinity, base: 51_638, rate: 0.45 },
     ],
   };
 
   /** @private @const {!Record<string, !Array<!TaxBracket>>} */
   static #NON_RESIDENT = {
-    '2019-20': [
-      {min: 0, max: 90_000, base: 0, rate: 0.325},
-      {min: 90_000, max: 180_000, base: 29_250, rate: 0.37},
-      {min: 180_000, max: Infinity, base: 62_550, rate: 0.45},
+    "2019-20": [
+      { min: 0, max: 90_000, base: 0, rate: 0.325 },
+      { min: 90_000, max: 180_000, base: 29_250, rate: 0.37 },
+      { min: 180_000, max: Infinity, base: 62_550, rate: 0.45 },
     ],
-    '2020-21': [
-      {min: 0, max: 120_000, base: 0, rate: 0.325},
-      {min: 120_000, max: 180_000, base: 39_000, rate: 0.37},
-      {min: 180_000, max: Infinity, base: 61_200, rate: 0.45},
+    "2020-21": [
+      { min: 0, max: 120_000, base: 0, rate: 0.325 },
+      { min: 120_000, max: 180_000, base: 39_000, rate: 0.37 },
+      { min: 180_000, max: Infinity, base: 61_200, rate: 0.45 },
     ],
     // FY 2021-22 & 2022-23 identical to 2020-21:
-    '2021-22': /** @type {!Array<!TaxBracket>} */ (null),
-    '2022-23': /** @type {!Array<!TaxBracket>} */ (null),
-    '2023-24': [
-      {min: 0, max: 120_000, base: 0, rate: 0.325},
-      {min: 120_000, max: 180_000, base: 39_000, rate: 0.37},
-      {min: 180_000, max: Infinity, base: 61_200, rate: 0.45},
+    "2021-22": /** @type {!Array<!TaxBracket>} */ (null),
+    "2022-23": /** @type {!Array<!TaxBracket>} */ (null),
+    "2023-24": [
+      { min: 0, max: 120_000, base: 0, rate: 0.325 },
+      { min: 120_000, max: 180_000, base: 39_000, rate: 0.37 },
+      { min: 180_000, max: Infinity, base: 61_200, rate: 0.45 },
     ],
-    '2024-25': [
-      {min: 0, max: 135_000, base: 0, rate: 0.30},
-      {min: 135_000, max: 190_000, base: 40_500, rate: 0.37},
-      {min: 190_000, max: Infinity, base: 60_850, rate: 0.45},
+    "2024-25": [
+      { min: 0, max: 135_000, base: 0, rate: 0.3 },
+      { min: 135_000, max: 190_000, base: 40_500, rate: 0.37 },
+      { min: 190_000, max: Infinity, base: 60_850, rate: 0.45 },
+    ],
+  };
+
+  /** @private @const {!Record<string, !Array<{min:number,max:number,rate:number}>>} */
+  static #HELP = {
+    "2024-25": [
+      { min: 0, max: 54_435, rate: 0 },
+      { min: 54_435, max: 62_188, rate: 0.01 },
+      { min: 62_188, max: 65_776, rate: 0.02 },
+      { min: 65_776, max: 69_591, rate: 0.025 },
+      { min: 69_591, max: 73_748, rate: 0.03 },
+      { min: 73_748, max: 78_172, rate: 0.035 },
+      { min: 78_172, max: 82_884, rate: 0.04 },
+      { min: 82_884, max: 87_903, rate: 0.045 },
+      { min: 87_903, max: 93_249, rate: 0.05 },
+      { min: 93_249, max: 98_935, rate: 0.055 },
+      { min: 98_935, max: 104_962, rate: 0.06 },
+      { min: 104_962, max: 111_359, rate: 0.065 },
+      { min: 111_359, max: 118_146, rate: 0.07 },
+      { min: 118_146, max: 125_344, rate: 0.075 },
+      { min: 125_344, max: 132_972, rate: 0.08 },
+      { min: 132_972, max: 141_056, rate: 0.085 },
+      { min: 141_056, max: 149_611, rate: 0.09 },
+      { min: 149_611, max: 158_660, rate: 0.095 },
+      { min: 158_660, max: Infinity, rate: 0.1 },
     ],
   };
 
   /** Collapse identical FY mappings declared as `null` above. */
   static {
-    ['2021-22', '2022-23'].forEach((fy) => {
-      AusTaxBrackets.#RESIDENT[fy] = AusTaxBrackets.#RESIDENT['2020-21'];
+    ["2021-22", "2022-23"].forEach((fy) => {
+      AusTaxBrackets.#RESIDENT[fy] = AusTaxBrackets.#RESIDENT["2020-21"];
       AusTaxBrackets.#NON_RESIDENT[fy] =
-          AusTaxBrackets.#NON_RESIDENT['2020-21'];
+        AusTaxBrackets.#NON_RESIDENT["2020-21"];
     });
   }
 
@@ -115,15 +140,16 @@ export class AusTaxBrackets {
    * @throws {RangeError} If data unavailable.
    */
   static getBrackets(fy, isResident = true) {
-    const src = isResident ? AusTaxBrackets.#RESIDENT
-                           : AusTaxBrackets.#NON_RESIDENT;
+    const src = isResident
+      ? AusTaxBrackets.#RESIDENT
+      : AusTaxBrackets.#NON_RESIDENT;
     let brackets = src[fy];
     if (!brackets) {
       const nearest = AusTaxBrackets.#nearestYear(fy, isResident);
       console.warn(`No bracket data for FY ${fy}; using ${nearest} instead.`);
       brackets = src[nearest];
     }
-    return brackets.map((b) => ({...b}));
+    return brackets.map((b) => ({ ...b }));
   }
 
   /**
@@ -136,7 +162,7 @@ export class AusTaxBrackets {
    */
   static calculateTax(income, fy, isResident = true) {
     if (income < 0 || !Number.isFinite(income)) {
-      throw new RangeError('Income must be a non-negative finite number.');
+      throw new RangeError("Income must be a non-negative finite number.");
     }
     const brackets = AusTaxBrackets.getBrackets(fy, isResident);
     const tier = brackets.find((b) => income < b.max);
@@ -164,10 +190,10 @@ export class AusTaxBrackets {
     const s = AusTaxBrackets.#toDate(start);
     const e = AusTaxBrackets.#toDate(end);
     if (e < s) {
-      throw new RangeError('End date must be on/after start date.');
+      throw new RangeError("End date must be on/after start date.");
     }
     if (annualSalary < 0 || !Number.isFinite(annualSalary)) {
-      throw new RangeError('Salary must be a non-negative finite number.');
+      throw new RangeError("Salary must be a non-negative finite number.");
     }
 
     let totalTax = 0;
@@ -180,7 +206,9 @@ export class AusTaxBrackets {
 
       const daysInSeg = AusTaxBrackets.#daysBetween(cursor, segEnd);
       const daysInFy = AusTaxBrackets.#daysBetween(
-          AusTaxBrackets.#startOfFy(fy), fyEnd);
+        AusTaxBrackets.#startOfFy(fy),
+        fyEnd,
+      );
 
       const segIncome = (annualSalary * daysInSeg) / daysInFy;
       totalTax += AusTaxBrackets.calculateTax(segIncome, fy, isResident);
@@ -189,6 +217,48 @@ export class AusTaxBrackets {
       cursor = new Date(fyEnd.getTime() + 86_400_000); // +1 day
     }
     return totalTax;
+  }
+
+  /**
+   * Returns the HELP repayment brackets for a financial year.
+   * @param {string} fy
+   * @return {!Array<{min:number,max:number,rate:number}>}
+   * @private
+   */
+  static #getHelpBrackets(fy) {
+    let brackets = AusTaxBrackets.#HELP[fy];
+    if (!brackets) {
+      const nearest = AusTaxBrackets.#nearestYear(fy, true);
+      console.warn(`No HELP data for FY ${fy}; using ${nearest} instead.`);
+      brackets = AusTaxBrackets.#HELP[nearest];
+    }
+    return brackets.map((b) => ({ ...b }));
+  }
+
+  /**
+   * Repayment rate for a given repayment income and FY.
+   * @param {number} income Repayment income ($).
+   * @param {string} fy     Financial year.
+   * @return {number} Rate as decimal.
+   */
+  static hecsRate(income, fy) {
+    if (income < 0 || !Number.isFinite(income)) {
+      throw new RangeError("Income must be a non-negative finite number.");
+    }
+    const brackets = AusTaxBrackets.#getHelpBrackets(fy);
+    const tier = brackets.find((b) => income < b.max);
+    if (!tier) throw new RangeError(`Incomplete HELP table for FY ${fy}.`);
+    return tier.rate;
+  }
+
+  /**
+   * Calculates annual HELP repayment for an income.
+   * @param {number} income Repayment income ($).
+   * @param {string} fy Financial year string.
+   * @return {number} Amount payable ($).
+   */
+  static hecsRepayment(income, fy) {
+    return income * AusTaxBrackets.hecsRate(income, fy);
   }
 
   // ---------------------------------------------------------------------------
@@ -222,8 +292,8 @@ export class AusTaxBrackets {
     const year = d.getFullYear();
     const isAfterJun = d.getMonth() >= 6; // July = 6
     const fyStart = isAfterJun ? year : year - 1;
-    const fyEnd = (fyStart + 1) % 100;      // 24 for 2023-24
-    return `${fyStart}-${fyEnd.toString().padStart(2, '0')}`;
+    const fyEnd = (fyStart + 1) % 100; // 24 for 2023-24
+    return `${fyStart}-${fyEnd.toString().padStart(2, "0")}`;
   }
 
   /**
@@ -268,13 +338,16 @@ export class AusTaxBrackets {
    * @private
    */
   static #nearestYear(target, isResident) {
-    const src = isResident ? AusTaxBrackets.#RESIDENT
-                           : AusTaxBrackets.#NON_RESIDENT;
+    const src = isResident
+      ? AusTaxBrackets.#RESIDENT
+      : AusTaxBrackets.#NON_RESIDENT;
     const tgt = parseInt(target.slice(0, 4), 10);
     const years = Object.keys(src).map((fy) => parseInt(fy.slice(0, 4), 10));
-    const nearestStart = years.reduce((best, y) =>
-      Math.abs(y - tgt) < Math.abs(best - tgt) ? y : best, years[0]);
-    const suffix = ((nearestStart + 1) % 100).toString().padStart(2, '0');
+    const nearestStart = years.reduce(
+      (best, y) => (Math.abs(y - tgt) < Math.abs(best - tgt) ? y : best),
+      years[0],
+    );
+    const suffix = ((nearestStart + 1) % 100).toString().padStart(2, "0");
     return `${nearestStart}-${suffix}`;
   }
 }
@@ -282,25 +355,37 @@ export class AusTaxBrackets {
 /* ---------------------------------------------------------------------------
  * === LIGHTWEIGHT SELF-TESTS (no production impact) ==========================
  * ------------------------------------------------------------------------- */
-if (import.meta.url.endsWith('aus_tax_brackets.js')) {
-  const assert = (cond, msg) => { if (!cond) { throw new Error(msg); } };
+if (import.meta.url.endsWith("aus_tax_brackets.js")) {
+  const assert = (cond, msg) => {
+    if (!cond) {
+      throw new Error(msg);
+    }
+  };
 
   // 1. Full FY ≙ period calc parity
-  const fy = '2024-25';
+  const fy = "2024-25";
   const salary = 100_000;
-  const fullYearTax =
-      AusTaxBrackets.calculateTax(salary, fy, true);
+  const fullYearTax = AusTaxBrackets.calculateTax(salary, fy, true);
 
   const periodTax = AusTaxBrackets.calculateTaxForPeriod(
-      '2024-07-01', '2025-06-30', salary, true);
-  assert(fullYearTax === periodTax,
-      'Full-year parity failed for resident FY 2024-25');
+    "2024-07-01",
+    "2025-06-30",
+    salary,
+    true,
+  );
+  assert(
+    fullYearTax === periodTax,
+    "Full-year parity failed for resident FY 2024-25",
+  );
 
   // 2. Cross-FY (half & half)
   const t = AusTaxBrackets.calculateTaxForPeriod(
-      '2024-01-01', '2024-12-31', 150_000, true);
-  assert(Number.isFinite(t) && t > 0,
-      'Cross-FY calculation failed.');
+    "2024-01-01",
+    "2024-12-31",
+    150_000,
+    true,
+  );
+  assert(Number.isFinite(t) && t > 0, "Cross-FY calculation failed.");
 
-  console.info('AusTaxBrackets smoke-tests passed.');
+  console.info("AusTaxBrackets smoke-tests passed.");
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -216,16 +216,75 @@
               title="Superannuation percentage, default 12%"
             />
           </div>
-          <div class="mb-3">
-            <label for="hecsRate" class="form-label">HECS Rate (%)</label>
-            <input
-              type="number"
-              id="hecsRate"
-              class="form-control"
-              value="0"
-              data-bs-toggle="tooltip"
-              title="Extra percentage to repay HECS/HELP debts"
-            />
+          <div class="form-check mb-3">
+            <input type="checkbox" id="hasHecs" class="form-check-input" />
+            <label class="form-check-label" for="hasHecs"
+              >I have a HECS/HELP debt</label
+            >
+          </div>
+          <div id="hecsSection" style="display: none">
+            <div class="mb-3">
+              <label for="riTaxable" class="form-label"
+                >Taxable income ($)</label
+              >
+              <input type="number" id="riTaxable" class="form-control" />
+            </div>
+            <div class="mb-3">
+              <label for="riNet" class="form-label"
+                >Net investment losses ($)</label
+              >
+              <input type="number" id="riNet" class="form-control" value="0" />
+            </div>
+            <div class="mb-3">
+              <label for="riFringe" class="form-label"
+                >Reportable fringe benefits ($)</label
+              >
+              <input
+                type="number"
+                id="riFringe"
+                class="form-control"
+                value="0"
+              />
+            </div>
+            <div class="mb-3">
+              <label for="riSuper" class="form-label"
+                >Reportable super contributions ($)</label
+              >
+              <input
+                type="number"
+                id="riSuper"
+                class="form-control"
+                value="0"
+              />
+            </div>
+            <div class="mb-3">
+              <label for="riExempt" class="form-label"
+                >Exempt foreign employment income ($)</label
+              >
+              <input
+                type="number"
+                id="riExempt"
+                class="form-control"
+                value="0"
+              />
+            </div>
+            <div class="mb-3">
+              <label for="riTotal" class="form-label"
+                >Repayment income ($)</label
+              >
+              <input type="number" id="riTotal" class="form-control" readonly />
+            </div>
+            <div class="mb-3">
+              <label for="hecsRate" class="form-label">HECS Rate (%)</label>
+              <input
+                type="number"
+                id="hecsRate"
+                class="form-control"
+                value="0"
+                data-bs-toggle="tooltip"
+                title="Extra percentage to repay HECS/HELP debts"
+              />
+            </div>
           </div>
 
           <div class="mb-3">


### PR DESCRIPTION
## Summary
- add HELP repayment tables and helper methods
- include HECS/HELP options and repayment income fields in the HTML form
- compute repayment income and automatically determine HELP rate in JS
- break down annual equivalent section with clearer details

Prettier was run on updated HTML, JS and helper files.
