### PR TITLE
Use advanced FTE conversion

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -136,6 +136,12 @@ button:hover {
   margin: 10px 0;
 }
 
+.fte-explainer {
+  font-size: 0.9em;
+  color: #555;
+  margin-top: 0.5em;
+}
+
 .pct-label {
   flex: 1;
   text-align: center;


### PR DESCRIPTION
## Summary
- import and use `FteConversion` for calculating Full‑Time Equivalent salary
- show a detailed explanation of the conversion in results
- style the new explanation block
- fix duplicate `hoursPerDay` variable

Prettier was run on `docs/script.js` and `docs/style.css`.
